### PR TITLE
Modified s3 url prefix for AWS endpoint accuracy

### DIFF
--- a/lib/RNS3.js
+++ b/lib/RNS3.js
@@ -33,7 +33,7 @@ export class RNS3 {
       date: new Date(),
       contentType: file.type
     };
-    var url = 'https://s3-' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    var url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
     const method = "POST";
     const policy = S3Policy.generate(options);
     return Request.create(url, method, policy).set("file", file).send().then(setBodyAsParsedXML);

--- a/lib/RNS3.js
+++ b/lib/RNS3.js
@@ -33,7 +33,14 @@ export class RNS3 {
       date: new Date(),
       contentType: file.type
     };
-    var url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+
+    var url
+    if (options.region) {
+      url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    } else {
+      url = 'https://s3.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    }
+
     const method = "POST";
     const policy = S3Policy.generate(options);
     return Request.create(url, method, policy).set("file", file).send().then(setBodyAsParsedXML);

--- a/src/RNS3.js
+++ b/src/RNS3.js
@@ -38,7 +38,7 @@ export class RNS3 {
       contentType: file.type
     }
 
-    var url = 'https://s3-' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    var url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
     const method = "POST"
     const policy = S3Policy.generate(options)
 

--- a/src/RNS3.js
+++ b/src/RNS3.js
@@ -38,7 +38,13 @@ export class RNS3 {
       contentType: file.type
     }
 
-    var url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    var url
+    if (options.region) {
+      url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    } else {
+      url = 'https://s3.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;
+    }
+    
     const method = "POST"
     const policy = S3Policy.generate(options)
 


### PR DESCRIPTION
`s3-` url prefix is out of date. AWS S3 endpoints now use `s3.` as a prefix. Incorporated this change into the url variable of `RNS3.put(file, options)`.

Example:
`var url = 'https://s3.' + options.region + '.' + (options.awsUrl || AWS_DEFAULT_S3_HOST) + '/' + options.bucket;`